### PR TITLE
Refactor, removed unconditional global

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The solution
 `argspec.js` offers a declarative way of dealing with optional arguments:
 
     function list(session, tx, callback) {
-      var args = argspec.getArgs(arguments, [
+      var args = argspec(arguments, [
         { name: 'session', optional: true, check: argspec.hasProperty('closeConn') },
         { name: 'tx', optional: true, check: argspec.hasProperty('executeSql') },
         { name: 'callback', optional: false, check: argspec.isCallback() }
@@ -58,14 +58,14 @@ The solution
       ...
     }
 
-The `argspec.getArgs(args, spec)` methods has two arguments:
+The `argspec(args, spec)` method has two arguments:
 
 * `args`
   An Javascript argument list (typically `arguments`, the built-in Javascript argument list)
 * `spec`
   An array of objects, defining each of the arguments. Each object has the following properties:
   * `name`: defines the argument name, is used as the name of the
-    argument in the object regurned by the `getArgs(..)` function.
+    argument in the object returned by the call to the `argspec` function.
   * `optional` (optional): defines whether the argument is optional (`true`) or not (`false`), default is `false`.
   * `check` (optional for required arguments): a function that will be passed the argument value and will check if it fits all the requirements. You can pass any function here, `argspec.js` comes with a number of utilty check-function producing functions:
       * `hasProperty(propname)`: checks if the object has the given property or not
@@ -73,12 +73,12 @@ The `argspec.getArgs(args, spec)` methods has two arguments:
       * `isCallback()`: checks if the object is callable
   * `defaultValue` (optional): a default value, if the argument is left out
 
-The object returned by `getArgs(..)` has a property for each argument.
+The object returned by `argspec(..)` has a property for each argument.
 
 Note that you can use `argspec.js` to do declarative argument value validation, even if you do not require optional arguments:
 
     function addNums(a, b) {
-      var args = getArgs(arguments, [
+      var args = argspec(arguments, [
         { name: 'a', check: argspec.hasType('number') },
         { name: 'b', check: argspec.hasType('number') }
       ]);

--- a/argspec.js
+++ b/argspec.js
@@ -23,61 +23,68 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-var argspec = {};
-
 (function() {
-    argspec.getArgs = function(args, specs) {
-      var argIdx = 0;
-      var specIdx = 0;
-      var argObj = {};
-      while(specIdx < specs.length) {
-        var s = specs[specIdx];
-        var a = args[argIdx];
-        if(s.optional) {
-          if(a !== undefined && s.check(a)) {
-            argObj[s.name] = a;
-            argIdx++;
-            specIdx++;
-          } else {
-            if(s.defaultValue) {
-              argObj[s.name] = s.defaultValue;
-            }
-            specIdx++;
-          }
-        } else {
-          if(s.check && !s.check(a)) {
-            throw "Invalid value for argument: " + s.name + " Value: " + a;
-          }
-          argObj[s.name] = a;
-          specIdx++;
-          argIdx++;
+  'use strict';
+
+  var argspec,
+      toString = Function.prototype.call.bind(Object.prototype.toString);
+
+  argspec = function (args, specs) {
+    var argument, argumentSpec, max,
+        argumentIndex = 0,
+        specIndex = 0,
+        argObj = {};
+
+    for (max = specs.length; specIndex < max; specIndex += 1) {
+      argumentSpec = specs[specIndex];
+      argument = args[argumentIndex];
+
+      if (argumentSpec.optional) {
+        if (argument !== undefined && argumentSpec.check(argument)) {
+          argObj[argumentSpec.name] = argument;
+          argumentIndex += 1;
+        } else if(argumentSpec.defaultValue) {
+          argObj[argumentSpec.name] = argumentSpec.defaultValue;
         }
+      } else {
+        if (argumentSpec.check && !argumentSpec.check(argument)) {
+          throw new TypeError('Invalid value for argument: ' + argumentSpec.name + ' Value: ' + argument);
+        }
+
+        argObj[argumentSpec.name] = argument;
+        argumentIndex += 1;
       }
-      return argObj;
     }
+    return argObj;
+  };
 
-    argspec.hasProperty = function(name) {
-      return function(obj) {
-        return obj[name] !== undefined;
-      };
-    }
+  argspec.hasProperty = function (name) {
+    return function(obj) {
+      return obj[name] !== undefined;
+    };
+  };
 
-    argspec.hasType = function(type) {
-      return function(obj) {
-        return typeof obj === type;
-      };
-    }
+  argspec.hasType = function (type) {
+    return function(obj) {
+      return toString(obj).split(' ')[1].slice(0, -1).toLowerCase() === type;
+    };
+  };
 
-    argspec.isCallback = function() {
-      return function(obj) {
-        return obj && obj.apply;
-      };
-    }
-    
-    argspec.isTypeof = function(type) {
-      return function(obj) {
-	    return obj.constructor.name === type;
-	  };
-	}
-    
-  }());
+  argspec.isTypeof = function (type) {
+    return function(obj) {
+      return obj.constructor.name === type;
+    };
+  };
+
+  argspec.isCallback = function () {
+    return function(obj) {
+      return obj && obj.apply;
+    };
+  };
+
+  if (typeof module !== 'undefined' && 'exports' in module) {
+    module.exports = argspec;
+  } else if (typeof window !== undefined) {
+    window.argspec = argspec;
+  }
+}());

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "main": "argspec.js",
   "ignore": [],
-  "homepage": "https://github.com/Rob-pw/argspecjs",
+  "homepage": "https://github.com/zefhemel/argspecjs",
   "authors": [
     "Zef Hemel <zef@zef.me>"
   ],

--- a/bower.json
+++ b/bower.json
@@ -5,8 +5,7 @@
   "ignore": [],
   "homepage": "https://github.com/Rob-pw/argspecjs",
   "authors": [
-    "Zef Hemel <zef@zef.me>",
-    "Robert White <hi@rob.pw>"
+    "Zef Hemel <zef@zef.me>"
   ],
   "description": "argspec.js is a simple optional argument handling library for Javascript.",
   "moduleType": [

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,26 @@
+{
+  "name": "argspecjs",
+  "version": "0.0.1",
+  "main": "argspec.js",
+  "ignore": [],
+  "homepage": "https://github.com/Rob-pw/argspecjs",
+  "authors": [
+    "Zef Hemel <zef@zef.me>",
+    "Robert White <hi@rob.pw>"
+  ],
+  "description": "argspec.js is a simple optional argument handling library for Javascript.",
+  "moduleType": [
+    "globals",
+    "node"
+  ],
+  "keywords": [
+    "argument",
+    "handling",
+    "optional",
+    "specification",
+    "polymorphic",
+    "enforcing",
+    "types"
+  ],
+  "license": "MIT"
+}


### PR DESCRIPTION
Noteworthy changes: argspec.getArgs functionality moved into
constructor, usage given by argspec(args, spec)
